### PR TITLE
Enable gosec in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,7 @@ linters:
     - goimports
     - gosimple
     - staticcheck
+    - gosec
   disable:
     - unused
     - unparam
@@ -82,5 +83,13 @@ issues:
     - Error return value of .*log\.Logger\)\.Log\x60 is not checked
     - Error return value of .*.Log.* is not checked
     - Error return value of `` is not checked
-
+    - G108 # Profiling endpoint automatically exposed on /debug/pprof
+    - G402 # Look for bad TLS connection settings
+    - G404 # Insecure random number source (rand)
+    - G501 # Import blocklist: crypto/md5
+    - G601 # Implicit memory aliasing of items from a range statement
+  exclude-rules:
+    - path: (.+)_test.go
+      linters:
+        - gosec
   fix: true

--- a/clients/cmd/docker-driver/main.go
+++ b/clients/cmd/docker-driver/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"time"
 
 	"github.com/docker/go-plugins-helpers/sdk"
 	"github.com/go-kit/log"
@@ -41,7 +42,12 @@ func main() {
 	pprofPort := os.Getenv("PPROF_PORT")
 	if pprofPort != "" {
 		go func() {
-			err := http.ListenAndServe(fmt.Sprintf(":%s", pprofPort), nil)
+			server := &http.Server{
+				Addr:              fmt.Sprintf(":%s", pprofPort),
+				ReadHeaderTimeout: 1 * time.Minute,
+			}
+
+			err := server.ListenAndServe()
 			logger.Log("msg", "http server stopped", "err", err)
 		}()
 	}

--- a/clients/pkg/promtail/promtail.go
+++ b/clients/pkg/promtail/promtail.go
@@ -1,7 +1,7 @@
 package promtail
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -120,7 +120,7 @@ func (p *Promtail) reloadConfig(cfg *config.Config) error {
 		return errConfigNotChange
 	}
 	newConf := cfg.String()
-	level.Info(p.logger).Log("msg", "Reloading configuration file", "md5sum", fmt.Sprintf("%x", md5.Sum([]byte(newConf))))
+	level.Info(p.logger).Log("msg", "Reloading configuration file", "sha256sum", fmt.Sprintf("%x", sha256.Sum256([]byte(newConf))))
 	if p.targetManagers != nil {
 		p.targetManagers.Stop()
 	}

--- a/clients/pkg/promtail/targets/syslog/transport.go
+++ b/clients/pkg/promtail/targets/syslog/transport.go
@@ -205,6 +205,7 @@ func newTLSConfig(certFile string, keyFile string, caFile string) (*tls.Config, 
 
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{certs},
+		MinVersion:   tls.VersionTLS12,
 	}
 
 	if caFile != "" {

--- a/cmd/loki-canary/main.go
+++ b/cmd/loki-canary/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -192,7 +191,12 @@ func main() {
 	})
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
-		err := http.ListenAndServe(":"+strconv.Itoa(*port), nil)
+		server := &http.Server{
+			Addr:              fmt.Sprintf(":%d", *port),
+			ReadHeaderTimeout: 1 * time.Minute,
+		}
+
+		err := server.ListenAndServe()
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -51,7 +51,12 @@ func main() {
 	flag.Parse()
 
 	go func() {
-		log.Println(http.ListenAndServe("localhost:8080", nil))
+		server := &http.Server{
+			Addr:              "localhost:8080",
+			ReadHeaderTimeout: 1 * time.Minute,
+		}
+
+		log.Println(server.ListenAndServe())
 	}()
 
 	// Create a set of defaults

--- a/integration/client/client.go
+++ b/integration/client/client.go
@@ -173,8 +173,7 @@ func (c *Client) Get(path string) (*http.Response, error) {
 
 // Get all the metrics
 func (c *Client) Metrics() (string, error) {
-	url := fmt.Sprintf("%s/metrics", c.baseURL)
-	res, err := http.Get(url)
+	res, err := http.Get(fmt.Sprintf("%s/metrics", c.baseURL))
 	if err != nil {
 		return "", err
 	}

--- a/operator/.golangci.yaml
+++ b/operator/.golangci.yaml
@@ -34,8 +34,11 @@ linters:
   - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
   - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
   - unused # Checks Go code for unused constants, variables, functions and types
+  - gosec # Inspects source code for security problems
 
 issues:
+  exclude:
+    - G404 # Insecure random number source (rand)
   exclude-use-default: false
   exclude-rules:
     # - text: "could be of size"

--- a/operator/cmd/loki-broker/main.go
+++ b/operator/cmd/loki-broker/main.go
@@ -183,7 +183,7 @@ func main() {
 		if cfg.writeToDir != "" {
 			basename := fmt.Sprintf("%s-%s.yaml", o.GetObjectKind().GroupVersionKind().Kind, o.GetName())
 			fname := strings.ToLower(path.Join(cfg.writeToDir, basename))
-			if err := os.WriteFile(fname, b, 0o644); err != nil {
+			if err := os.WriteFile(fname, b, 0o600); err != nil {
 				logger.Error(err, "failed to write file to directory", "path", fname)
 				os.Exit(1)
 			}

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -1,7 +1,7 @@
 package manifests
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -28,7 +28,7 @@ func LokiConfigMap(opt Options) (*corev1.ConfigMap, string, error) {
 		return nil, "", err
 	}
 
-	s := sha1.New()
+	s := sha256.New()
 	_, err = s.Write(c)
 	if err != nil {
 		return nil, "", err

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -1,7 +1,7 @@
 package manifests
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"path"
 	"regexp"
@@ -357,7 +357,7 @@ func gatewayConfigMap(opt Options) (*corev1.ConfigMap, string, error) {
 		return nil, "", err
 	}
 
-	s := sha1.New()
+	s := sha256.New()
 	_, err = s.Write(tenantsConfig)
 	if err != nil {
 		return nil, "", err

--- a/operator/internal/manifests/storage/configure.go
+++ b/operator/internal/manifests/storage/configure.go
@@ -14,10 +14,12 @@ import (
 
 const (
 	// EnvGoogleApplicationCredentials is the environment variable to specify path to key.json
+	// #nosec G101 -- This is a false positive
 	EnvGoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
 	// GCSFileName is the file containing the Google credentials for authentication
 	GCSFileName = "key.json"
 
+	// #nosec G101 -- This is a false positive
 	secretDirectory = "/etc/storage/secrets"
 	caDirectory     = "/etc/storage/ca"
 )

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -60,6 +60,7 @@ const (
 	// PrometheusCAFile declares the path for prometheus CA file for service monitors.
 	PrometheusCAFile string = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
 	// BearerTokenFile declares the path for bearer token file for service monitors.
+	// #nosec G101 -- This is a false positive
 	BearerTokenFile string = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 	// labelJobComponent is a ServiceMonitor.Spec.JobLabel.

--- a/pkg/ruler/base/mapper.go
+++ b/pkg/ruler/base/mapper.go
@@ -1,7 +1,7 @@
 package base
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -148,8 +148,8 @@ func (m *mapper) writeRuleGroupsIfNewer(groups []rulefmt.RuleGroup, filename str
 		if err != nil {
 			return false, err
 		}
-		newHash := md5.New()
-		currentHash := md5.New()
+		newHash := sha256.New()
+		currentHash := sha256.New()
 
 		// bailout if there is no update
 		if string(currentHash.Sum(current)) == string(newHash.Sum(d)) {

--- a/pkg/storage/stores/indexshipper/compactor/testutil.go
+++ b/pkg/storage/stores/indexshipper/compactor/testutil.go
@@ -81,7 +81,7 @@ func SetupTable(t *testing.T, path string, commonDBsConfig IndexesConfig, perUse
 	idx := 0
 	for filename, content := range commonIndexes {
 		filePath := filepath.Join(path, strings.TrimSuffix(filename, ".gz"))
-		require.NoError(t, os.WriteFile(filePath, []byte(content), 0777))
+		require.NoError(t, os.WriteFile(filePath, []byte(content), 0600))
 		if strings.HasSuffix(filename, ".gz") {
 			compressFile(t, filePath)
 		}
@@ -92,7 +92,7 @@ func SetupTable(t *testing.T, path string, commonDBsConfig IndexesConfig, perUse
 		require.NoError(t, util.EnsureDirectory(filepath.Join(path, userID)))
 		for filename, content := range files {
 			filePath := filepath.Join(path, userID, strings.TrimSuffix(filename, ".gz"))
-			require.NoError(t, os.WriteFile(filePath, []byte(content), 0777))
+			require.NoError(t, os.WriteFile(filePath, []byte(content), 0600))
 			if strings.HasSuffix(filename, ".gz") {
 				compressFile(t, filePath)
 			}

--- a/pkg/storage/stores/indexshipper/downloads/testutil.go
+++ b/pkg/storage/stores/indexshipper/downloads/testutil.go
@@ -39,7 +39,7 @@ func setupIndexesAtPath(t *testing.T, userID, path string, start, end int) []str
 		fileName := buildIndexFilename(userID, start)
 		indexPath := filepath.Join(path, fileName)
 
-		require.NoError(t, os.WriteFile(indexPath, []byte(fileName), 0755))
+		require.NoError(t, os.WriteFile(indexPath, []byte(fileName), 0600))
 		testIndexes = append(testIndexes, indexPath)
 	}
 

--- a/pkg/storage/stores/shipper/shipper_index_client.go
+++ b/pkg/storage/stores/shipper/shipper_index_client.go
@@ -125,7 +125,7 @@ func (i *indexClient) getUploaderName() (string, error) {
 		if !os.IsNotExist(err) {
 			return "", err
 		}
-		if err := os.WriteFile(uploaderFilePath, []byte(uploader), 0o666); err != nil {
+		if err := os.WriteFile(uploaderFilePath, []byte(uploader), 0600); err != nil {
 			return "", err
 		}
 	} else {

--- a/pkg/util/shard.go
+++ b/pkg/util/shard.go
@@ -19,6 +19,8 @@ var (
 // ShuffleShardSeed returns seed for random number generator, computed from provided identifier.
 func ShuffleShardSeed(identifier, zone string) int64 {
 	// Use the identifier to compute an hash we'll use to seed the random.
+	// #nosec G401 -- This is a false positive: the generated checksum is only using
+	// for random number generation and not for any verification.
 	hasher := md5.New()
 	hasher.Write(YoloBuf(identifier)) // nolint:errcheck
 	if zone != "" {

--- a/tools/querytee/instrumentation.go
+++ b/tools/querytee/instrumentation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
@@ -39,7 +40,8 @@ func (s *InstrumentationServer) Start() error {
 	router.Handle("/metrics", promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{}))
 
 	s.srv = &http.Server{
-		Handler: router,
+		Handler:           router,
+		ReadHeaderTimeout: 1 * time.Minute,
 	}
 
 	go func() {

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -196,9 +196,10 @@ func (p *Proxy) Start() error {
 
 	p.srvListener = listener
 	p.srv = &http.Server{
-		ReadTimeout:  1 * time.Minute,
-		WriteTimeout: 2 * time.Minute,
-		Handler:      router,
+		ReadTimeout:       1 * time.Minute,
+		ReadHeaderTimeout: 1 * time.Minute,
+		WriteTimeout:      2 * time.Minute,
+		Handler:           router,
 	}
 
 	// Run in a dedicated goroutine.


### PR DESCRIPTION
gosec inspects source code for security problems. These vulnerabilities need to be found and fixed in code

- Enable gosec in root module
- Enable gosec in operator module
- Fix vulnerabilities reported by gosec

Signed-off-by: Akhil Mohan <akhilerm@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
